### PR TITLE
CFG: 4 new functions

### DIFF
--- a/src/tools/cfg/bir_cfgVizLib.sml
+++ b/src/tools/cfg/bir_cfgVizLib.sml
@@ -1,11 +1,15 @@
-
+open HolKernel Parse;
 open bir_immSyntax;
-
 open graphVizLib;
+open bir_cfgLib;
 
 
 structure bir_cfgVizLib =
 struct
+
+val ERR = mk_HOL_ERR "bir_cfgVizLib"
+
+(*---------------------------------------------------------------------------*)
 
 val eval_label = (snd o dest_eq o concl o EVAL);
 
@@ -16,22 +20,23 @@ fun ziplist [] [] = []
 fun unziplist [] = ([],[])
   | unziplist ((x,y)::xys) = let val (xs,ys) = unziplist xys; in (x::xs,y::ys) end;
 
-fun convert_inout_to_graphviz idxs_sel (blocks,in_idxs,out_idxs) =
+(*---------------------------------------------------------------------------*)
+
+fun convert_inout_to_graphviz idxs_sel (blocks, in_idxs, out_idxs) =
   let
-    fun block_to_node (i, block) =
+    fun block_to_node (i,block) =
       let
-        val (raw_BL_term, _, _) = dest_bir_block block;
+        val (raw_BL_term,_,_) = dest_bir_block block;
         val label = eval_label raw_BL_term;
-        val label_str = if is_BL_Label label then
-                      dest_BL_Label_string label
-                    else if is_BL_Address label then
-                      (term_to_string o snd o gen_dest_Imm o dest_BL_Address) label
-                    else
-                      raise ERR "convert_inout_tographviz" "label type unknown";
-(*        val label_str = (term_to_string o eval_label) raw_BL_term;*)
-        val node = (i,node_shape_default,[("id", label_str)]);
+        val label_str =
+          if is_BL_Label label then
+            dest_BL_Label_string label
+          else if is_BL_Address label then
+            (term_to_string o snd o gen_dest_Imm o dest_BL_Address) label
+          else
+            raise ERR "convert_inout_to_graphviz" "label type unknown";
       in
-        node
+        (i,node_shape_default,[("id",label_str)])
       end;
 
     fun listcontains l x = List.exists (fn y => y = x) l;
@@ -42,7 +47,7 @@ fun convert_inout_to_graphviz idxs_sel (blocks,in_idxs,out_idxs) =
         val (nodes_aux,edges,i_aux) =
           if ins = [] then
             ((i_aux,node_shape_point,[])::nodes_aux, (i_aux,i)::edges, i_aux+1)
-   (*         (nodes_aux,edges,i_aux) *)
+            (* (nodes_aux,edges,i_aux) *)
           else
             (nodes_aux,edges,i_aux);
         val (nodes_aux,edges,i_aux) = List.foldl (fn (in_idx,(nodes_aux,edges,i_aux)) =>
@@ -79,31 +84,69 @@ fun convert_inout_to_graphviz idxs_sel (blocks,in_idxs,out_idxs) =
   end;
 
 fun convert_inout_to_graphviz_all (blocks,in_idxs,out_idxs) =
-  convert_inout_to_graphviz (List.tabulate(length blocks, fn x => x)) (blocks,in_idxs,out_idxs);
+  convert_inout_to_graphviz
+    (List.tabulate(length blocks, fn x => x))
+    (blocks,in_idxs,out_idxs);
 
+(*---------------------------------------------------------------------------*)
 
-(*
-val g = (blocks,in_idxs,out_idxs);
-*)
-
-
-fun bir_show_graph_inout simplified nodes g =
+fun bir_export_graph_inout simplified nodes g path =
   let
     val (nodes, edges) = convert_inout_to_graphviz nodes g;
     val (nodes, edges) = if simplified then simplify_graph (nodes, edges) else (nodes, edges);
-    val dirname = "tempdir";
+
+    val path = if (String.size (OS.Path.dir path)) = 0 then ("./" ^ path) else path;
+    val dirname = OS.Path.dir path;
     val _ = OS.FileSys.isDir dirname handle SysErr(_) => (OS.FileSys.mkDir dirname; true);
-    val file = dirname ^ "/temp_file_" ^ (Int.toString(Time.toMilliseconds(Time.now())));
+
     val dot_str = gen_graph (nodes, edges);
-    val _ = writeToFile dot_str (file ^ ".dot");
-    val _ = convertAndView file;
+    val _ = writeToFile dot_str path;
   in
     ()
   end;
 
-fun bir_show_graph_inout_all simplified (blocks,in_idxs,out_idxs) =
-  bir_show_graph_inout simplified (List.tabulate(length blocks, fn x => x)) (blocks,in_idxs,out_idxs)
+fun bir_export_graph_inout_all simplified (blocks, in_idxs, out_idxs) path =
+  bir_export_graph_inout
+    simplified
+    (List.tabulate (length blocks, fn x => x))
+    (blocks, in_idxs, out_idxs)
+    path;
 
+(*---------------------------------------------------------------------------*)
 
-end
+fun bir_show_graph_inout simplified nodes g =
+  let
+    val path = "tempdir/temp_file_" ^ (LargeInt.toString (Time.toMilliseconds (Time.now ())));
+    val _ = bir_export_graph_inout simplified nodes g (path ^ ".dot");
+    val _ = convertAndView path;
+  in
+    ()
+  end;
 
+fun bir_show_graph_inout_all simplified (blocks, in_idxs, out_idxs) =
+  bir_show_graph_inout
+    simplified
+    (List.tabulate (length blocks, fn x => x))
+    (blocks, in_idxs, out_idxs);
+
+(*---------------------------------------------------------------------------*)
+
+fun bir_export_graph_from_prog prog path =
+  let
+    val blocks = (fst o dest_list o dest_BirProgram) prog;
+    val (_, in_idxs, out_idxs) = cfg_compute_inoutedges_as_idxs blocks;
+    val simplified = false;
+  in
+    bir_export_graph_inout_all simplified (blocks, in_idxs, out_idxs) path
+  end;
+
+fun bir_show_graph_from_prog prog path =
+  let
+    val blocks = (fst o dest_list o dest_BirProgram) prog;
+    val (_, in_idxs, out_idxs) = cfg_compute_inoutedges_as_idxs blocks;
+    val simplified = false;
+  in
+    bir_show_graph_inout_all simplified (blocks, in_idxs, out_idxs)
+  end;
+
+end (* bir_cfgVizLib *)

--- a/src/tools/cfg/graphVizLib.sml
+++ b/src/tools/cfg/graphVizLib.sml
@@ -43,7 +43,7 @@ fun gen_node (idx, shape, label_lines) =
 fun gen_nodes nodes =
   let
     val nodes_strs = List.map gen_node nodes;
-    val str = List.foldl (fn (x,y) => y ^ x ^ "\r\n\r\n") "" nodes_strs;
+    val str = List.foldr (fn (x,y) => y ^ x ^ "\r\n\r\n") "" nodes_strs;
   in
     str
   end;


### PR DESCRIPTION
I created 4 new functions in `bir_cfgVizLib.sml`:
- `bir_export_graph_inout simplified nodes g path`
- `bir_export_graph_inout_all simplified (blocks, in_idxs, out_idxs) path`
- `bir_export_graph_from_prog prog path`
- `bir_show_graph_from_prog prog path`

I extracted the first two from the `bir_show_xxx` functions, and added the last two for ease of use.